### PR TITLE
artefact upload added

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,15 +19,9 @@ jobs:
           args: latexmk -pdf -cd -interaction=nonstopmode -file-line-error -jobname=analysis_III -outdir=../build ./src/main.tex
       - name: reset flags
         run: sed 's/^/%/' -i src/headers/flags.tex
-      - name: Archive analysis_III_full.pdf as artifacts
+      - name: Archive pdf's as artifacts
         uses: actions/upload-artifact@v3
         with:
-          name: compiled-analysis_III_full
-          path: build/analysis_III_full.pdf
+          name: compiled-pdf
+          path: build/*.pdf
           retention-days: 5
-      - name: Archive analysis_III.pdf as artifacts
-        uses: actions/upload-artifact@v3
-        with:
-            name: compiled-analysis_III
-            path: build/analysis_III.pdf
-            retention-days: 5

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,9 +19,15 @@ jobs:
           args: latexmk -pdf -cd -interaction=nonstopmode -file-line-error -jobname=analysis_III -outdir=../build ./src/main.tex
       - name: reset flags
         run: sed 's/^/%/' -i src/headers/flags.tex
-      - name: Archive pdf's as artifacts
+      - name: Archive analysis_III_full.pdf as artifacts
         uses: actions/upload-artifact@v3
         with:
-          name: compiled-pdf
-          path: build/*.pdf
+          name: compiled-analysis_III_full
+          path: build/analysis_III_full.pdf
           retention-days: 5
+      - name: Archive analysis_III.pdf as artifacts
+        uses: actions/upload-artifact@v3
+        with:
+            name: compiled-analysis_III
+            path: build/analysis_III.pdf
+            retention-days: 5

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,5 +23,5 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: compiled-pdf
-          path: ../build/*.pdf
+          path: build/*.pdf
           retention-days: 5

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,3 +19,9 @@ jobs:
           args: latexmk -pdf -cd -interaction=nonstopmode -file-line-error -jobname=analysis_III -outdir=../build ./src/main.tex
       - name: reset flags
         run: sed 's/^/%/' -i src/headers/flags.tex
+      - name: Archive pdf's as artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: compiled-pdf
+          path: ../build/*.pdf
+          retention-days: 5


### PR DESCRIPTION
The compiled pdf's are now stored as artifacts for 5 days.
Just click on the CI job (Show all checks -> Details) and then select the Summary tab. There you can download a zip file containing the pdf's. 
Unfortunately it is not possible to directly download the pdf files. Even a single pdf file gets compressed into a zip file.
[See limitations](https://github.com/actions/upload-artifact#limitations)